### PR TITLE
fix: add required header for Linux

### DIFF
--- a/source/dsp56kEmu/logging.h
+++ b/source/dsp56kEmu/logging.h
@@ -3,6 +3,7 @@
 #include <sstream>
 #include <string>
 #include <iomanip>
+#include <memory>
 
 namespace Logging
 {


### PR DESCRIPTION
The build fails to build from source due to a missing header, as per the following output:

	[ 47%] Built target asmjit
	[ 48%] Building CXX object source/dsp56kEmu/CMakeFiles/dsp56kEmu.dir/agu.cpp.o
	[ 49%] Building CXX object source/dsp56kEmu/CMakeFiles/dsp56kEmu.dir/audio.cpp.o
	In file included from /tmp/github.com-dsp56300-dsp56300/source/dsp56kEmu/audio.h:8,
	                 from /tmp/github.com-dsp56300-dsp56300/source/dsp56kEmu/audio.cpp:1:
	/tmp/github.com-dsp56300-dsp56300/source/dsp56kEmu/logging.h: In function ‘std::string Logging::string_format(const std::string&, Args ...)’:
	/tmp/github.com-dsp56300-dsp56300/source/dsp56kEmu/logging.h:19:33: error: ‘make_unique’ is not a member of ‘std’
	   19 |                 auto buf = std::make_unique<char[]>( size );
	      |                                 ^~~~~~~~~~~
	/tmp/github.com-dsp56300-dsp56300/source/dsp56kEmu/logging.h:6:1: note: ‘std::make_unique’ is defined in header ‘<memory>’; did you forget to ‘#include <memory>’?
	    5 | #include <iomanip>
	  +++ |+#include <memory>
	    6 |
	/tmp/github.com-dsp56300-dsp56300/source/dsp56kEmu/logging.h:19:45: error: expected primary-expression before ‘char’
	   19 |                 auto buf = std::make_unique<char[]>( size );
	      |                                             ^~~~
	make[2]: *** [source/dsp56kEmu/CMakeFiles/dsp56kEmu.dir/build.make:90: source/dsp56kEmu/CMakeFiles/dsp56kEmu.dir/audio.cpp.o] Error 1
	make[1]: *** [CMakeFiles/Makefile2:193: source/dsp56kEmu/CMakeFiles/dsp56kEmu.dir/all] Error 2
	make: *** [Makefile:146: all] Error 2

The patch has been available [downstream][0] (Arch Linux's AUR) for a while with no issues.

[0]: https://aur.archlinux.org/cgit/aur.git/tree/fix-ftbfs-dsp56300.patch?h=dsp56300-emulator