### PR TITLE
Fix two macOS thread-timing bugs found while investigating idle CPU usage

### DIFF
--- a/source/dsp56kBase/threadtools.cpp
+++ b/source/dsp56kBase/threadtools.cpp
@@ -183,14 +183,14 @@ namespace dsp56k
 	bool ThreadTools::setCurrentThreadRealtimeParameters(int _samplerate, int _blocksize)
 	{
 #ifdef __APPLE__
-		bool usePeriod = true;
-		if (_samplerate)
-		{
-			// set some reasonable realtime parameters for audio processing, disable fixed call frequency
-			_samplerate = 44100;
-			_blocksize = 2048;
-			usePeriod = false;
-		}
+		// Without real timing info from the caller (the common case: _samplerate == 0), fall back to
+		// reasonable realtime parameters for audio processing, non-periodic. Note that _samplerate/_blocksize
+		// are always overridden here regardless of the values passed in - dividing by a caller-supplied
+		// _samplerate of 0 below would produce NaN, and casting NaN to uint32_t is undefined behavior.
+		_samplerate = 44100;
+		_blocksize = 2048;
+		constexpr bool usePeriod = false;
+
 	    // Compute the nominal "period" between activations, in microseconds.
 	    // Example: 44100 Hz, 1024 buffer => 23,219 us
 	    double periodUsec = static_cast<double>(_blocksize) * 1'000'000.0 / static_cast<double>(_samplerate);

--- a/source/dsp56kEmu/dsp.h
+++ b/source/dsp56kEmu/dsp.h
@@ -350,6 +350,8 @@ namespace dsp56k
 			m_cycles += _cycles;
 		}
 
+		TInterruptFunc getExecPeripheralsFunc() const noexcept { return m_execPeripheralsFunc; }
+
 	private:
 
 		std::string getSSindent() const;

--- a/source/dsp56kEmu/jitops_jmp.cpp
+++ b/source/dsp56kEmu/jitops_jmp.cpp
@@ -13,7 +13,13 @@ namespace dsp56k
 //		m_asm.imul(r32(count), asmjit::Imm(cycles));
 //		m_block.increaseCycleCount(r32(count));
 
-		_dsp->fastForward(_instructions, _instructions);
+		// getRemainingInstructionsFor*FrameSync() deliberately stops 1 cycle short of the target, normally relying on
+		// the caller's next real instruction dispatch to close that final cycle and trigger peripheral processing.
+		// This call site replaces the polling instruction entirely (it's a JIT-detected spinloop-on-self idiom), so
+		// there is no such subsequent real instruction - without closing the gap here and forcing peripheral
+		// processing immediately, this becomes a busy-spin that never converges on its own.
+		_dsp->fastForward(_instructions + 1, _instructions + 1);
+		_dsp->getExecPeripheralsFunc()(_dsp);
 	}
 
 	template<bool ExpectedValue>


### PR DESCRIPTION
## Summary
- `ThreadTools::setCurrentThreadRealtimeParameters()` divided by a caller-supplied `_samplerate` of 0 (the only call site always passes `(0, 0)`), producing NaN and then casting it to `uint32_t` for the Mach `THREAD_TIME_CONSTRAINT_POLICY` call - undefined behavior, empirically confirmed to yield large garbage values on Apple Silicon/clang. Fixed by always applying the fallback realtime parameters, since the only caller never supplies real timing info anyway.
- The JIT's ESAI frame-sync spinloop optimization (`skipToFrameSync`, used when the JIT detects firmware polling a "jump to self while testing the frame-sync bit" idiom) fast-forwards the DSP's virtual instruction/cycle counters but deliberately stops 1 cycle short of the real target, relying on a subsequent real instruction dispatch to close the gap and trigger peripheral processing. Since this optimization *replaces* the polling instruction entirely, there is no such subsequent instruction, so the polled bit never flips and the loop never converges - it just calls the helper over and over (measured at several million calls/sec) until an unrelated interrupt happens to break it from a different code path. Fixed by closing the gap and forcing peripheral processing immediately, mirroring what `op_Wait()` already does.

Both were found while investigating a real-world CPU usage report on OsTIrus/Virus TI in Bitwig on macOS (Apple Silicon): CPU dropping while notes are actively playing and climbing once idle. Neither fix fully explains that symptom (measured directly: the frame-sync spinloop's call rate stays flat through the climb, both before and after this fix), which further profiling points to being macOS/SoC-level clock frequency scaling rather than an emulator bug - but both are real, independent correctness/efficiency issues worth fixing regardless.

## Test plan
- [x] Clean Release build on macOS (Xcode/arm64+x86_64 universal)
- [x] Verified via targeted instrumentation that the frame-sync spinloop call rate drops (~5M/s -> ~2.4M/s) after the fix
- [x] CI build across all platforms/synths