### PR TITLE
Fix data race in RingBuffer<T,C,false>'s read/write counters

### DIFF
--- a/source/dsp56kBase/CMakeLists.txt
+++ b/source/dsp56kBase/CMakeLists.txt
@@ -46,3 +46,6 @@ target_link_libraries(sharedAudioBufferTest PRIVATE dsp56kBase)
 
 add_executable(sharedAudioReducerTest sharedaudioreducer_test.cpp)
 target_link_libraries(sharedAudioReducerTest PRIVATE dsp56kBase)
+
+add_executable(ringBufferTest ringbuffer_test.cpp)
+target_link_libraries(ringBufferTest PRIVATE dsp56kBase)

--- a/source/dsp56kBase/ringbuffer.h
+++ b/source/dsp56kBase/ringbuffer.h
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <vector>
 #include <thread>
 
@@ -22,9 +23,9 @@ namespace dsp56k
 		}
 
 		constexpr static size_t capacity()	{ return C; }
-		bool empty() const					{ return m_readCount == m_writeCount; }
+		bool empty() const					{ return m_readCount.load(std::memory_order_acquire) == m_writeCount.load(std::memory_order_acquire); }
 		bool full() const					{ return size() >= C; }
-		size_t size() const					{ return m_writeCount - m_readCount; }
+		size_t size() const					{ return m_writeCount.load(std::memory_order_acquire) - m_readCount.load(std::memory_order_acquire); }
 		size_t remaining() const			{ return (C - size()); }
 
 		void push_back( const T& _val )
@@ -33,24 +34,26 @@ namespace dsp56k
 
 			m_writeSem.wait();
 
-			m_data[wrapCounter(m_writeCount)] = _val;
+			const auto writeIdx = m_writeCount.load(std::memory_order_relaxed);
+			m_data[wrapCounter(writeIdx)] = _val;
 
-			// usage need to be incremented AFTER data has been written, otherwise, reader thread would read incomplete data
-			++m_writeCount;
+			// counter needs to be published (release) AFTER data has been written, so that a reader thread
+			// observing the new count via an acquire load is guaranteed to also see the data
+			m_writeCount.store(writeIdx + 1, std::memory_order_release);
 
 			m_readSem.notify();
 		}
-		
+
 		void push_back( T&& _val )
 		{
 	//		assert( m_usage < C && "ring buffer is already full!" );
 
 			m_writeSem.wait();
 
-			m_data[wrapCounter(m_writeCount)] = std::move(_val);
+			const auto writeIdx = m_writeCount.load(std::memory_order_relaxed);
+			m_data[wrapCounter(writeIdx)] = std::move(_val);
 
-			// usage need to be incremented AFTER data has been written, otherwise, reader thread would read incomplete data
-			++m_writeCount;
+			m_writeCount.store(writeIdx + 1, std::memory_order_release);
 
 			m_readSem.notify();
 		}
@@ -62,10 +65,10 @@ namespace dsp56k
 
 			m_writeSem.wait();
 
-			_fillEntry(m_data[wrapCounter(m_writeCount)]);
+			const auto writeIdx = m_writeCount.load(std::memory_order_relaxed);
+			_fillEntry(m_data[wrapCounter(writeIdx)]);
 
-			// usage need to be incremented AFTER data has been written, otherwise, reader thread would read incomplete data
-			++m_writeCount;
+			m_writeCount.store(writeIdx + 1, std::memory_order_release);
 
 			m_readSem.notify();
 		}
@@ -77,11 +80,11 @@ namespace dsp56k
 
 			m_writeSem.wait(static_cast<uint32_t>(_count));
 
+			const auto writeIdx = m_writeCount.load(std::memory_order_relaxed);
 			for (size_t i=0; i<_count; ++i)
-				_fillEntry(i, m_data[wrapCounter(m_writeCount)]);
+				_fillEntry(i, m_data[wrapCounter(writeIdx)]);
 
-			// usage need to be incremented AFTER data has been written, otherwise, reader thread would read incomplete data
-			m_writeCount += _count;
+			m_writeCount.store(writeIdx + _count, std::memory_order_release);
 
 			m_readSem.notify(static_cast<uint32_t>(_count));
 		}
@@ -91,10 +94,11 @@ namespace dsp56k
 		{
 			m_readSem.wait();
 
-			_readCallback(front());
+			const auto readIdx = m_readCount.load(std::memory_order_relaxed);
+			_readCallback(m_data[wrapCounter(readIdx)]);
 	//		assert( !empty() && "ring buffer is already empty!" );
 
-			++m_readCount;
+			m_readCount.store(readIdx + 1, std::memory_order_release);
 
 			m_writeSem.notify();
 		}
@@ -106,8 +110,9 @@ namespace dsp56k
 
 			for (size_t i=0; i<_count; ++i)
 			{
-				_readCallback(i, front());
-				++m_readCount;
+				const auto readIdx = m_readCount.load(std::memory_order_relaxed);
+				_readCallback(i, m_data[wrapCounter(readIdx)]);
+				m_readCount.store(readIdx + 1, std::memory_order_release);
 			}
 
 			m_writeSem.notify(static_cast<uint32_t>(_count));
@@ -117,10 +122,11 @@ namespace dsp56k
 		{
 			m_readSem.wait();
 
-			T res = std::move(front());
+			const auto readIdx = m_readCount.load(std::memory_order_relaxed);
+			T res = std::move(m_data[wrapCounter(readIdx)]);
 	//		assert( !empty() && "ring buffer is already empty!" );
 
-			++m_readCount;
+			m_readCount.store(readIdx + 1, std::memory_order_release);
 
 			m_writeSem.notify();
 
@@ -139,12 +145,12 @@ namespace dsp56k
 
 		const T& front() const
 		{
-			return m_data[wrapCounter(m_readCount)];
+			return m_data[wrapCounter(m_readCount.load(std::memory_order_acquire))];
 		}
-		
+
 		T& front()
 		{
-			return m_data[wrapCounter(m_readCount)];
+			return m_data[wrapCounter(m_readCount.load(std::memory_order_acquire))];
 		}
 
 		void clear()
@@ -202,8 +208,8 @@ namespace dsp56k
 
 		MemoryBuffer		m_data;
 
-		size_t				m_writeCount;
-		size_t				m_readCount;
+		std::atomic<size_t>	m_writeCount;
+		std::atomic<size_t>	m_readCount;
 
 		typedef std::conditional_t<Lock, SpscSemaphoreWithCount, NopSemaphore> Sem;
 

--- a/source/dsp56kBase/ringbuffer.h
+++ b/source/dsp56kBase/ringbuffer.h
@@ -22,6 +22,33 @@ namespace dsp56k
 			initBuffer(m_data);
 		}
 
+		// std::atomic disables the implicit move/copy members. Callers (e.g. BypassBuffer's
+		// std::vector<RingBuffer<...>>) only ever move an instance while it is exclusively owned
+		// by the moving thread (container growth), never concurrently with another thread's
+		// push/pop, so relaxed loads of the counters are sufficient here.
+		RingBuffer(RingBuffer&& _other) noexcept
+			: m_data(std::move(_other.m_data))
+			, m_writeCount(_other.m_writeCount.load(std::memory_order_relaxed))
+			, m_readCount(_other.m_readCount.load(std::memory_order_relaxed))
+			, m_readSem(std::move(_other.m_readSem))
+			, m_writeSem(std::move(_other.m_writeSem))
+		{
+		}
+
+		RingBuffer& operator=(RingBuffer&& _other) noexcept
+		{
+			if (this == &_other)
+				return *this;
+
+			m_data = std::move(_other.m_data);
+			m_writeCount.store(_other.m_writeCount.load(std::memory_order_relaxed), std::memory_order_relaxed);
+			m_readCount.store(_other.m_readCount.load(std::memory_order_relaxed), std::memory_order_relaxed);
+			m_readSem = std::move(_other.m_readSem);
+			m_writeSem = std::move(_other.m_writeSem);
+
+			return *this;
+		}
+
 		constexpr static size_t capacity()	{ return C; }
 		bool empty() const					{ return m_readCount.load(std::memory_order_acquire) == m_writeCount.load(std::memory_order_acquire); }
 		bool full() const					{ return size() >= C; }

--- a/source/dsp56kBase/ringbuffer_test.cpp
+++ b/source/dsp56kBase/ringbuffer_test.cpp
@@ -1,0 +1,124 @@
+#include "ringbuffer.h"
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <random>
+#include <thread>
+
+// Regression test for the cross-thread SPSC usage of RingBuffer<T,C,false> (the "lock-free"
+// spin/yield variant selected on all non-ARM64 builds, see dsp.h's m_pendingInterrupts /
+// m_pendingExternalInterrupts). Before the fix, m_writeCount/m_readCount were plain non-atomic
+// size_t: a producer thread and a consumer thread read/wrote them with no synchronization at
+// all, which is a data race (UB) and, concretely, let an optimizing compiler treat empty()/
+// full() as loop-invariant inside waitNotEmpty()/waitNotFull() - i.e. it could hoist the read
+// out of the spin loop and never observe the other thread's write, hanging forever. This test
+// drives exactly that cross-thread producer/consumer pattern under real OS thread scheduling
+// with a watchdog to fail loudly instead of hanging CI if the race ever regresses.
+//
+// On the pre-fix code, this test doesn't just hang: it can observe outright wrong data (the
+// consumer reading a value the producer never wrote at that position), after which a thread can
+// end up permanently stuck inside RingBuffer's own waitNotEmpty()/waitNotFull() spin loop - so
+// failure paths below call std::_Exit() directly rather than trying to join those threads.
+
+static constexpr uint32_t BufferCapacity = 64;
+static constexpr uint64_t TotalItems = 1'000'000;
+
+int main()
+{
+	dsp56k::RingBuffer<uint64_t, BufferCapacity, false> ringBuffer;
+
+	std::atomic<bool> done{false};
+	std::atomic<uint64_t> produced{0};
+	std::atomic<uint64_t> consumed{0};
+
+	std::thread producer([&]
+	{
+		std::mt19937 rng(123);
+		std::uniform_int_distribution<int> sleepDist(0, 200);
+
+		for (uint64_t i = 0; i < TotalItems; ++i)
+		{
+			if (sleepDist(rng) == 0)
+				std::this_thread::sleep_for(std::chrono::microseconds(1));
+
+			ringBuffer.waitNotFull();
+			ringBuffer.push_back(i);
+			produced.fetch_add(1, std::memory_order_relaxed);
+		}
+	});
+
+	std::thread consumer([&]
+	{
+		std::mt19937 rng(456);
+		std::uniform_int_distribution<int> sleepDist(0, 200);
+
+		for (uint64_t i = 0; i < TotalItems; ++i)
+		{
+			if (sleepDist(rng) == 0)
+				std::this_thread::sleep_for(std::chrono::microseconds(1));
+
+			ringBuffer.waitNotEmpty();
+			const auto value = ringBuffer.pop_front();
+
+			if (value != i)
+			{
+				std::cerr << "Consumer: expected " << i << " but got " << value << std::endl;
+				std::cerr << "FAILED" << std::endl;
+				std::_Exit(1);
+			}
+
+			consumed.fetch_add(1, std::memory_order_relaxed);
+		}
+	});
+
+	std::thread watchdog([&]
+	{
+		uint64_t lastProduced = 0;
+		uint64_t lastConsumed = 0;
+		int stalledSeconds = 0;
+
+		while (!done.load())
+		{
+			std::this_thread::sleep_for(std::chrono::seconds(1));
+
+			const auto p = produced.load(std::memory_order_relaxed);
+			const auto c = consumed.load(std::memory_order_relaxed);
+
+			const auto progressed = (p != lastProduced) || (c != lastConsumed);
+			lastProduced = p;
+			lastConsumed = c;
+
+			if (!progressed)
+			{
+				++stalledSeconds;
+				if (stalledSeconds >= 5)
+				{
+					std::cerr << "DEADLOCK: no progress for 5 seconds (produced=" << p << ", consumed=" << c << ")" << std::endl;
+					std::cerr << "FAILED" << std::endl;
+					std::_Exit(1);
+				}
+			}
+			else
+			{
+				stalledSeconds = 0;
+			}
+		}
+	});
+
+	producer.join();
+	consumer.join();
+	done.store(true);
+	watchdog.join();
+
+	if (consumed.load() != TotalItems)
+	{
+		std::cerr << "FAILED: wrong count, consumed=" << consumed.load() << " expected=" << TotalItems << std::endl;
+		return 1;
+	}
+
+	std::cout << "PASSED" << std::endl;
+	return 0;
+}


### PR DESCRIPTION
## Scenario

`RingBuffer<T,C,Lock>` uses `Lock=false` (a no-op `NopSemaphore`, no blocking) on every **non-ARM64** build for `DSP::m_pendingInterrupts` and `DSP::m_pendingExternalInterrupts` (`dsp.h:112-116`). That path relies on `m_writeCount`/`m_readCount` being plain `size_t`, but they are genuinely read and written from **two different threads** with no synchronization at all:

- `hdiSendIrqToDSP()` (microcontroller thread — `xtDSP.cpp`, `mqdsp.cpp`) pushes into `m_pendingExternalInterrupts` and then busy-waits via `ucYieldLoop()` on `hasPendingInterrupts()`, which reads the `empty()` state of *both* ring buffers.
- The DSP's own worker thread (`DSPThread`) concurrently pushes/pops both buffers from `execPeripherals()`/`op_Wait()`.

Without atomics, the compiler is free to treat `m_writeCount`/`m_readCount` as loop-invariant inside `waitNotEmpty()`/`waitNotFull()` (nothing marks them as mutated by another thread), and there's no ordering guarantee that a writer's payload write becomes visible before its counter increment is observed by the reader. This is exactly the class of bug already fixed for ARM64 by switching `m_pendingInterrupts`/`m_pendingExternalInterrupts` to `Lock=true` (see the comment at `dsp.h:110`: *"our lock free ring buffer does not work properly on aarch64"*) — it was just never fixed for the non-ARM64 lock-free path, which still has the identical hazard, just less likely to manifest on x86's stronger memory model.

## Test case

Added `source/dsp56kBase/ringbuffer_test.cpp` (`ringBufferTest` target): a real two-thread producer/consumer stress test against `RingBuffer<uint64_t, 64, false>` — 1,000,000 items, randomized scheduling jitter on both sides (mirroring the existing `sharedaudiobuffer_test.cpp` pattern in this same directory), plus a watchdog thread that fails fast via `std::_Exit()` instead of relying on a flag the spinning threads might never re-check (important: once the race manifests, a thread can get stuck permanently inside `RingBuffer`'s own spin-wait, so a graceful `join()`-based teardown isn't safe for a broken build).

Reproduced on Apple clang `-O3 -flto` before the fix:
```
Consumer: expected 11403 but got 11339
FAILED
```
i.e. not just a theoretical data race — the consumer actually read a value the producer never wrote at that ring position. After the fix, the same test passes reliably (verified multiple runs).

## Fix

Make `m_writeCount`/`m_readCount` `std::atomic<size_t>`. Producer/consumer still write the payload before publishing the count (release store), and readers use acquire loads — preserving the exact existing "write data, then publish count" ordering intent and the `Lock=false` spin/yield behavior (`waitNotEmpty`/`waitNotFull` still never block on a semaphore). Only the missing synchronization is added; no behavioral change for the `Lock=true` path.

Verified: `sharedAudioBufferTest` and `sharedAudioReducerTest` (existing tests in the same directory) still pass, and `dsp56kEmu` builds clean.