### PR TITLE
Interpreter: account instruction cycles in non-JIT builds

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(ASMJIT_STATIC TRUE)
 
 option(DSP56300_DEBUGGER "Build wxWidgets based debugger" OFF)
+option(DSP56K_FORCE_INTERPRETER "Disable the JIT and use the interpreter" OFF)
 
 add_subdirectory(asmjit)
 add_subdirectory(dsp56kBase)

--- a/source/dsp56kEmu/CMakeLists.txt
+++ b/source/dsp56kEmu/CMakeLists.txt
@@ -131,6 +131,10 @@ else()
 	target_compile_definitions(dsp56kEmu PUBLIC DSP56300_DEBUGGER=0)
 endif()
 
+if(DSP56K_FORCE_INTERPRETER)
+	target_compile_definitions(dsp56kEmu PUBLIC DSP56K_FORCE_INTERPRETER=1)
+endif()
+
 # This should use ${PROJECT_SOURCE_DIR}/source if the top level of the repo
 # has the top level cmakelists.txt file.
 target_include_directories(dsp56kEmu PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)

--- a/source/dsp56kEmu/dsp.cpp
+++ b/source/dsp56kEmu/dsp.cpp
@@ -13,6 +13,7 @@
 #include "debuggerinterface.h"
 #include "dspconfig.h"
 #include "interrupts.h"
+#include "opcodecycles.h"
 
 #include "dsp_decode.inl"
 
@@ -328,6 +329,9 @@ namespace dsp56k
 		{
 			++m_instructions;
 
+			if constexpr(!g_useJIT)
+				m_cycles += getOpcodeCycles(currentOp);
+
 			if(g_traceSupported && pcCurrentInstruction == currentOp)
 				traceOp();
 		}
@@ -492,6 +496,9 @@ namespace dsp56k
 		
 		sr_set( SR_LF );
 
+		if constexpr(!g_useJIT)
+			m_cycles += getOpcodeCycles(pcCurrentInstruction);
+
 		++m_instructions;
 
 		traceOp();
@@ -548,11 +555,15 @@ namespace dsp56k
 		const auto lcBackup = reg.lc;
 		reg.lc.var = _loopCount;
 
+		if constexpr(!g_useJIT)
+			m_cycles += getOpcodeCycles(pcCurrentInstruction);
+
 		++m_instructions;
 
 		traceOp();
 
 		pcCurrentInstruction = reg.pc.var;
+		const auto repeatedOpPC = pcCurrentInstruction;
 		const auto op = fetchPC();
 
 		--reg.lc.var;
@@ -567,6 +578,8 @@ namespace dsp56k
 			--reg.lc.var;
 			(this->*func)(op);
 			++m_instructions;
+			if constexpr(!g_useJIT)
+				m_cycles += getOpcodeCycles(repeatedOpPC);
 //			traceOp();
 		}
 
@@ -1030,6 +1043,8 @@ namespace dsp56k
 	void DSP::notifyProgramMemWrite(TWord _offset)
 	{
 		m_opcodeCache[_offset].op = &DSP::op_ResolveCache;
+		if constexpr(!g_useJIT)
+			m_opcodeCycleCache[_offset] = 0;
 
 #if DSP56300_DEBUGGER
 		if(m_debugger)
@@ -1273,15 +1288,38 @@ namespace dsp56k
 			injectInterrupt(m_pendingExternalInterrupts.pop_front());
 	}
 
+	uint32_t DSP::calcOpcodeCycles(const TWord _pc) const
+	{
+		TWord opA;
+		TWord opB;
+		mem.getOpcode(_pc, opA, opB);
+		Instruction instA;
+		Instruction instB;
+		m_opcodes.getInstructionTypes(opA, instA, instB);
+		return dsp56k::calcCycles(instA, instB, _pc, opA, mem.getBridgedMemoryAddress(), 1);
+	}
+
+	uint8_t DSP::getOpcodeCycles(const TWord _pc)
+	{
+		auto& cachedCycles = m_opcodeCycleCache[_pc];
+		if(!cachedCycles)
+			cachedCycles = static_cast<uint8_t>(std::min<uint32_t>(255, std::max<uint32_t>(1, calcOpcodeCycles(_pc))));
+		return cachedCycles;
+	}
+
 	void DSP::clearOpcodeCache()
 	{
 		m_opcodeCache.clear();
 		m_opcodeCache.resize(mem.sizeP(), {&DSP::op_ResolveCache});
+		if constexpr(!g_useJIT)
+			m_opcodeCycleCache.assign(mem.sizeP(), 0);
 	}
 
 	void DSP::clearOpcodeCache(const TWord _address)
 	{
 		m_opcodeCache[_address].op = &DSP::op_ResolveCache;
+		if constexpr(!g_useJIT)
+			m_opcodeCycleCache[_address] = 0;
 		m_jit.notifyProgramMemWrite(_address);
 	}
 	

--- a/source/dsp56kEmu/dsp.h
+++ b/source/dsp56kEmu/dsp.h
@@ -122,6 +122,10 @@ namespace dsp56k
 		};
 
 		std::vector<OpcodeCacheEntry>	m_opcodeCache;
+
+		// Per-PC instruction cycle count, filled lazily in interpreter builds. JIT builds leave
+		// this vector empty because they account cycles per compiled block. 0 = not yet computed.
+		std::vector<uint8_t>			m_opcodeCycleCache;
 		
 		InstructionCache				cache;
 
@@ -291,6 +295,11 @@ namespace dsp56k
 
 		void			clearOpcodeCache				();
 		void			clearOpcodeCache				(TWord _address);
+
+		// Cycle count of the instruction at _pc. Delegates to the same shared dsp56k::calcCycles()
+		// that JitOps/JitBlock use, so there is no second implementation that could drift.
+		uint32_t		calcOpcodeCycles				(TWord _pc) const;
+		uint8_t			getOpcodeCycles				(TWord _pc);
 
 		void			dumpRegisters					() const;
 		void			dumpRegisters					(std::stringstream& _ss) const;

--- a/source/dsp56kEmu/dspconfig.h
+++ b/source/dsp56kEmu/dspconfig.h
@@ -10,7 +10,7 @@ namespace dsp56k
 	constexpr bool g_useAARTranslate = false;
 #endif
 
-#if defined(HAVE_X86_64) || defined(HAVE_ARM64)
+#if !defined(DSP56K_FORCE_INTERPRETER) && (defined(HAVE_X86_64) || defined(HAVE_ARM64))
 	constexpr bool g_jitSupported = true;
 #else
 	constexpr bool g_jitSupported = false;

--- a/source/dsp56kEmu/interpreterunittests.cpp
+++ b/source/dsp56kEmu/interpreterunittests.cpp
@@ -10,8 +10,57 @@ namespace dsp56k
 	{
 		testCCCC();
 		testSubr();
+		testCycleAccounting();
 		
 		runAllTests();
+	}
+
+	void InterpreterUnitTests::testCycleAccounting()
+	{
+		if constexpr(g_useJIT)
+		{
+			// Normal JIT builds must not pay for the interpreter-only per-PC cache.
+			verify(dsp.m_opcodeCycleCache.empty());
+			return;
+		}
+
+		verify(dsp.m_opcodeCycleCache.size() == dsp.memory().sizeP());
+
+		// A cached instruction cost is used on execution and invalidated by P writes.
+		dsp.resetHW();
+		execOpcode(assembler.assemble("nop").word[0], 0, false, 0x100);
+		verify(dsp.getCycles() == 1);
+		verify(dsp.m_opcodeCycleCache[0x100] == 1);
+
+		const auto andi = assembler.assemble("andi #$33,mr");
+		verify(andi.success());
+		dsp.memWriteP(0x100, andi.word[0]);
+		if(andi.wordCount > 1)
+			dsp.memWriteP(0x101, andi.word[1]);
+		verify(dsp.m_opcodeCycleCache[0x100] == 0);
+		dsp.setPC(0x100);
+		dsp.execInterpreter();
+		verify(dsp.getCycles() == 4);
+		verify(dsp.m_opcodeCycleCache[0x100] == 3);
+
+		// REP executes its own instruction plus the repeated body inside one interpreter step.
+		dsp.resetHW();
+		TWord pc = 0x100;
+		pc = emitToMemory("rep #$4", pc);
+		emitToMemory("nop", pc);
+		dsp.setPC(0x100);
+		dsp.execInterpreter();
+		verify(dsp.getCycles() == 9); // REP (5) + four NOPs (1 each)
+
+		// DO likewise runs its loop body internally rather than returning through execOp per pass.
+		dsp.resetHW();
+		pc = 0x100;
+		pc = emitToMemory("do #$5,>$104", pc);
+		pc = emitToMemory("nop", pc);
+		emitToMemory("nop", pc);
+		dsp.setPC(0x100);
+		dsp.execInterpreter();
+		verify(dsp.getCycles() == 15); // DO (5) + five two-NOP iterations
 	}
 
 	void InterpreterUnitTests::execOpcode(uint32_t _op0, uint32_t _op1, const bool _reset, TWord _pc)

--- a/source/dsp56kEmu/interpreterunittests.h
+++ b/source/dsp56kEmu/interpreterunittests.h
@@ -12,6 +12,7 @@ namespace dsp56k
 		void testSubr();
 		void testCCCC();
 		void testCCCC(int64_t _val, int64_t _compareValue, bool _lt, bool _le, bool _eq, bool _ge, bool _gt, bool _neq);
+		void testCycleAccounting();
 
 		void runTest(const std::function<void()>& _build, const std::function<void()>& _verify) override;
 		void emit(TWord _opA, TWord _opB = 0, TWord _pc = 0) override;


### PR DESCRIPTION
Fixes #6.

Non-JIT builds incremented `m_instructions` but never advanced `m_cycles`. Components that use cycles as their time base therefore saw a clock that remained at zero.

### Approach

- Account interpreter instructions with the same shared `dsp56k::calcCycles()` implementation used by the JIT.
- Cache the calculated cost per program address and invalidate it alongside the existing opcode cache after P-memory writes.
- Account instructions executed inside the interpreter's `REP` and `DO` helpers, which do not all return through the ordinary `execOp()` path.
- Allocate the per-PC cycle cache only in interpreter builds. Normal JIT builds leave it empty, and all interpreter accounting is removed at compile time with `if constexpr`.
- Add `DSP56K_FORCE_INTERPRETER` so the non-JIT path can be built and tested explicitly on JIT-capable hosts.

### Validation

- Release build and full CTest suite, normal JIT configuration: **5/5 passed**.
- Release build and full CTest suite, `DSP56K_FORCE_INTERPRETER=ON`: **5/5 passed**.
- New unit coverage checks ordinary instruction costs, P-memory cache invalidation, `REP`, `DO`, and that a JIT build does not allocate the interpreter cache.
- Three independent negative controls (removing ordinary, repeated-body, or `DO` accounting) each made the new unit test fail; restoring the patch returned it to green.
- Built Gearmulator `main` (`803fc747`) with DSP56300 `c051afad` and with this commit, then rendered 10,000 blocks through the real OsTIrus VST3 and `pluginTester`, using the same private Virus TI firmware and alternating binaries in one Release build. Eight complete runs per variant produced median elapsed times of **4.053 s baseline** and **4.058 s patched** (+0.12%); means were **4.065 s** and **4.058 s**. This is noise-level equivalence and supports no JIT/audio hot-path regression.

During an earlier exploratory timing sequence, the unmodified baseline plugin had one intermittent startup segfault. It was not counted as a completed render; the reported 16-run sequence subsequently completed without failures.

### Scope

The behavioral change is limited to interpreter builds. It affects users of the interpreter cycle counter while preserving normal JIT cycle accounting and performance.
