### PR TITLE
Disassembler: reject reserved JJJ=000 parallel-move ADD/SUB encodings

### DIFF
--- a/source/dsp56kEmu/assemblertest.cpp
+++ b/source/dsp56kEmu/assemblertest.cpp
@@ -22,6 +22,7 @@ namespace dsp56k
 		testMiscInstructions();
 		testParallelInstructions();
 		testPeripheralSymbols();
+		testReservedAluEncodings();
 
 		std::cout << "Assembler tests: " << m_passCount << "/" << m_testCount << " passed";
 		if(m_failCount > 0)
@@ -80,6 +81,120 @@ namespace dsp56k
 		}
 
 		++m_passCount;
+	}
+
+	void AssemblerTest::expectReserved(uint32_t _opA, uint32_t _opB)
+	{
+		++m_testCount;
+
+		Opcodes opcodes;
+		Disassembler disasm(opcodes);
+
+		Disassembler::Line line;
+		const auto wordCount = disasm.disassemble(line, _opA, _opB, 0, 0, 0);
+
+		// A reserved encoding must be refused outright. A zero return is what makes the
+		// caller emit a single dc word and resume decoding at _opA + 1, so an extension
+		// word belonging to the parallel move is released rather than swallowed.
+		if(wordCount != 0)
+		{
+			++m_failCount;
+			std::cout << "FAIL: reserved 0x" << std::hex << _opA;
+			if(_opB) std::cout << " 0x" << _opB;
+			std::cout << " decoded as \"" << Disassembler::formatLine(line, false)
+			          << "\" (" << std::dec << wordCount << " words), expected dc" << std::endl;
+			return;
+		}
+
+		// The classification surface must agree with the rendered text. These are the
+		// two instructions that carry a Table 12-13 JJJ field, so neither may claim it.
+		Instruction a = Invalid, b = Invalid;
+		opcodes.getInstructionTypes(_opA, a, b);
+
+		if(a == Add_SD || b == Add_SD || a == Sub_SD || b == Sub_SD)
+		{
+			++m_failCount;
+			std::cout << "FAIL: reserved 0x" << std::hex << _opA << std::dec
+			          << " renders as dc but still classifies as Add_SD/Sub_SD ("
+			          << static_cast<int>(a) << "," << static_cast<int>(b) << ")" << std::endl;
+			return;
+		}
+
+		// If an extension word was supplied, the refusal must not have consumed it: it
+		// belongs to the following address and has to decode there on its own. Asserting
+		// only that _opA returns zero does not establish that - the count and the
+		// independent decode are separate properties, and testing one and claiming the
+		// other is how a test comes to assert less than its comment says.
+		if(_opB)
+		{
+			Disassembler::Line next;
+			if(disasm.disassemble(next, _opB, 0, 0, 0, 0) == 0)
+			{
+				++m_failCount;
+				std::cout << "FAIL: reserved 0x" << std::hex << _opA
+				          << "'s extension word 0x" << _opB << std::dec
+				          << " does not decode independently at the next address" << std::endl;
+				return;
+			}
+		}
+
+		++m_passCount;
+	}
+
+	void AssemblerTest::expectDecodes(uint32_t _opA, uint32_t _opB)
+	{
+		++m_testCount;
+
+		Opcodes opcodes;
+		Disassembler disasm(opcodes);
+
+		Disassembler::Line line;
+		if(disasm.disassemble(line, _opA, _opB, 0, 0, 0) == 0)
+		{
+			++m_failCount;
+			std::cout << "FAIL: 0x" << std::hex << _opA;
+			if(_opB) std::cout << " 0x" << _opB;
+			std::cout << std::dec << " expected to decode, got dc" << std::endl;
+			return;
+		}
+
+		++m_passCount;
+	}
+
+	void AssemblerTest::testReservedAluEncodings()
+	{
+		// DSP56300 Family Manual Table 12-13 assigns the parallel-move ADD/SUB source
+		// field JJJ over 001..111. 000 is reserved and has no operand.
+		//
+		// Decoding it as if it were 001 is not merely a cosmetic mis-naming: the text it
+		// produced re-assembled to a DIFFERENT word. Motorola asm56300 6.3.15 turned the
+		// disassembly of 0x102a04 back into 0x102a14, with no errors reported - a silent
+		// round-trip corruption. These cases lock that shut.
+
+		// JJJ=000 with kkk=000: the ADD form.
+		expectReserved(0x200008);
+
+		// JJJ=000 with the two SUB forms.
+		expectReserved(0x200004);
+		expectReserved(0x20000c);
+
+		// The measured corruption case, with a full parallel move attached.
+		expectReserved(0x102a04);
+
+		// A reserved ALU whose parallel move carries an extension word. The extension
+		// must remain independently decodable at the following address rather than being
+		// consumed by the failed instruction.
+		expectReserved(0x16b408, 0x379823);
+
+		// Controls. Every legal neighbour must be unaffected - the first patch attempt at
+		// this fix broke five of six mnemonics because it was validated on two words
+		// instead of against the instruction inventory.
+		expectDecodes(0x200010);	// add b,a     - Table 12-13, JJJ=001
+		expectDecodes(0x3cfb1c);	// sub         - Table 12-13
+		expectDecodes(0x9c1c05);	// cmp         - Table 12-16, where JJJ=000 IS legal
+		expectDecodes(0xd37307);	// cmpm        - Table 12-16
+		expectDecodes(0x200001);	// tfr         - Table 12-16
+		expectDecodes(0x030000);	// Tcc         - Table 12-16
 	}
 
 	void AssemblerTest::testAluInstructions()

--- a/source/dsp56kEmu/assemblertest.h
+++ b/source/dsp56kEmu/assemblertest.h
@@ -15,6 +15,13 @@ namespace dsp56k
 		// Round-trip test: disassemble hex → assemble text → verify hex matches
 		void roundTrip(uint32_t _opA, uint32_t _opB = 0);
 
+		// Assert a word is refused by the decoder (rendered as dc), and that neither
+		// Add_SD nor Sub_SD claims it.
+		void expectReserved(uint32_t _opA, uint32_t _opB = 0);
+
+		// Assert a word still decodes to a non-dc instruction.
+		void expectDecodes(uint32_t _opA, uint32_t _opB = 0);
+
 		// Test individual instruction categories
 		void testAluInstructions();
 		void testMoveInstructions();
@@ -24,6 +31,7 @@ namespace dsp56k
 		void testMiscInstructions();
 		void testParallelInstructions();
 		void testPeripheralSymbols();
+		void testReservedAluEncodings();
 
 		uint32_t m_testCount = 0;
 		uint32_t m_passCount = 0;

--- a/source/dsp56kEmu/opcodes.h
+++ b/source/dsp56kEmu/opcodes.h
@@ -162,6 +162,12 @@ namespace dsp56k
 					if(v > 0 && v < 4)
 						return false;
 					break;
+				case Add_SD:
+				case Sub_SD:
+					// The other variant: Table 12-13 assigns JJJ=001..111; 000 is reserved.
+					if(v == 0)
+						return false;
+					break;
 				default:;
 				}
 			}


### PR DESCRIPTION
DSP56300 Family Manual Table 12-13 assigns `JJJ=001..111` for the parallel-move ADD/SUB source field; `000` is reserved. The decoder previously accepted `000` as the `001` form, which could render text that reassembled to a different opcode word.

This change rejects `JJJ=000` only for `Add_SD` and `Sub_SD`. Legal neighboring encodings, including Table 12-16 instructions where `JJJ=000` is valid, remain accepted.

Validation:

- Release build on current `dsp56300`
- `dsp56300_unitTests` passed
- focused tests cover the three reserved forms, an extension-word case, and legal neighbors
- final Gemini 3.1 Pro High review: `APPROVE`, no required fixes

Performance: the added comparison is in decode/classification. It does not add work to already emitted JIT code or interpreter instruction bodies.
