### PR TITLE
Disassembler: add -nops to print zero-word NOPs

### DIFF
--- a/source/disassemble/CMakeLists.txt
+++ b/source/disassemble/CMakeLists.txt
@@ -7,3 +7,13 @@ add_executable(dsp56kDisassemble)
 target_sources(dsp56kDisassemble PRIVATE disassemble.cpp commandline.cpp commandline.h)
 
 target_link_libraries(dsp56kDisassemble PRIVATE dsp56kEmu)
+
+if(BUILD_TESTING)
+	add_test(
+		NAME dsp56kDisassembleZeroWords
+		COMMAND ${CMAKE_COMMAND}
+			-DDISASSEMBLER=$<TARGET_FILE:dsp56kDisassemble>
+			-DTEST_WORK_DIR=${CMAKE_CURRENT_BINARY_DIR}/test
+			-P ${CMAKE_CURRENT_SOURCE_DIR}/disassemble_test.cmake
+	)
+endif()

--- a/source/disassemble/disassemble.cpp
+++ b/source/disassemble/disassemble.cpp
@@ -152,7 +152,7 @@ int main(int _argc, char* _argv[])
 			std::cout << "-s filename      Specify file with additional symbols in format S:abcdef=name, where S = X, Y, L, P or I." << std::endl;
 			std::cout << "-pc aabbcc       Set base address in hex. Defaults to 0 if omitted." << std::endl;
 			std::cout << "le               Specify that the input file is in Little-Endian format. By default, input bytes are treated as being Big-Endian." << std::endl;
-			std::cout << "-skipnops        Omit $000000 (nop) words from the output unless they are branch targets. This is LOSSY: the listing then no longer tiles the input, which severs the fall-through edge into whatever follows a run of nops. Off by default; provided only to reproduce output from before that default changed." << std::endl;
+			std::cout << "-nops            Print $000000 (nop) words instead of omitting them. By default they are skipped, which keeps padded ROM listings readable but is lossy: the listing then no longer tiles the input, so the instruction after a run of nops loses its fall-through predecessor." << std::endl;
 			std::cout << std::endl;
 			std::cout << "Output format:" << std::endl;
 			std::cout << "[address] - [opcode word A] [opcode word B] = [assembly]" << std::endl;
@@ -182,12 +182,12 @@ int main(int _argc, char* _argv[])
 
 		const auto bigEndian = !cmd.contains("le");
 
-		// A $000000 word is a real, executed NOP with a real fall-through edge. Dropping
-		// it makes the listing stop tiling the input: the instruction after a run of nops
-		// loses its only predecessor, so any consumer that walks fall-through edges reports
-		// it as unreachable. Print every word by default; -skipnops restores the old,
-		// lossy rendering for reproducing pre-existing listings.
-		const auto skipNops = cmd.contains("skipnops");
+		// A $000000 word is a real, executed NOP with a real fall-through edge. Omitting it
+		// makes the listing stop tiling the input, so the instruction after a run of nops
+		// loses its only predecessor and reads as unreachable to anything walking those
+		// edges. That matters for analysis; for reading a padded ROM the suppression is
+		// what makes the output legible, so it stays the default and -nops opts in.
+		const auto skipNops = !cmd.contains("nops");
 
 		std::vector<TWord> input;
 		if (!loadInputFile(input, inFile, bigEndian))

--- a/source/disassemble/disassemble.cpp
+++ b/source/disassemble/disassemble.cpp
@@ -152,6 +152,7 @@ int main(int _argc, char* _argv[])
 			std::cout << "-s filename      Specify file with additional symbols in format S:abcdef=name, where S = X, Y, L, P or I." << std::endl;
 			std::cout << "-pc aabbcc       Set base address in hex. Defaults to 0 if omitted." << std::endl;
 			std::cout << "le               Specify that the input file is in Little-Endian format. By default, input bytes are treated as being Big-Endian." << std::endl;
+			std::cout << "-skipnops        Omit $000000 (nop) words from the output unless they are branch targets. This is LOSSY: the listing then no longer tiles the input, which severs the fall-through edge into whatever follows a run of nops. Off by default; provided only to reproduce output from before that default changed." << std::endl;
 			std::cout << std::endl;
 			std::cout << "Output format:" << std::endl;
 			std::cout << "[address] - [opcode word A] [opcode word B] = [assembly]" << std::endl;
@@ -180,6 +181,13 @@ int main(int _argc, char* _argv[])
 		std::basic_ostream<char>& out = outf ? *outf : std::cout;
 
 		const auto bigEndian = !cmd.contains("le");
+
+		// A $000000 word is a real, executed NOP with a real fall-through edge. Dropping
+		// it makes the listing stop tiling the input: the instruction after a run of nops
+		// loses its only predecessor, so any consumer that walks fall-through edges reports
+		// it as unreachable. Print every word by default; -skipnops restores the old,
+		// lossy rendering for reproducing pre-existing listings.
+		const auto skipNops = cmd.contains("skipnops");
 
 		std::vector<TWord> input;
 		if (!loadInputFile(input, inFile, bigEndian))
@@ -263,7 +271,7 @@ int main(int _argc, char* _argv[])
 		}
 
 		std::string assembly;
-		disasm.disassembleMemoryBlock(assembly, input, pc, true, true, true);
+		disasm.disassembleMemoryBlock(assembly, input, pc, skipNops, true, true);
 
 		out << assembly;
 

--- a/source/disassemble/disassemble_test.cmake
+++ b/source/disassemble/disassemble_test.cmake
@@ -1,0 +1,44 @@
+if(NOT DEFINED DISASSEMBLER OR NOT DEFINED TEST_WORK_DIR)
+	message(FATAL_ERROR "DISASSEMBLER and TEST_WORK_DIR are required")
+endif()
+
+file(MAKE_DIRECTORY "${TEST_WORK_DIR}")
+set(input_file "${TEST_WORK_DIR}/zero_words.txt")
+file(WRITE "${input_file}" "000000 000004\n")
+
+execute_process(
+	COMMAND "${DISASSEMBLER}" -in "${input_file}" -pc 1
+	RESULT_VARIABLE default_result
+	OUTPUT_VARIABLE default_output
+	ERROR_VARIABLE default_error
+)
+
+if(NOT default_result EQUAL 0)
+	message(FATAL_ERROR
+		"Default disassembly failed (${default_result})\n${default_output}${default_error}")
+endif()
+
+if(NOT default_output MATCHES "000001:.*nop")
+	message(FATAL_ERROR "Default output omitted the zero-word NOP:\n${default_output}")
+endif()
+
+execute_process(
+	COMMAND "${DISASSEMBLER}" -in "${input_file}" -pc 1 -skipnops
+	RESULT_VARIABLE skipped_result
+	OUTPUT_VARIABLE skipped_output
+	ERROR_VARIABLE skipped_error
+)
+
+if(NOT skipped_result EQUAL 0)
+	message(FATAL_ERROR
+		"-skipnops disassembly failed (${skipped_result})\n${skipped_output}${skipped_error}")
+endif()
+
+if(skipped_output MATCHES "000001:.*nop")
+	message(FATAL_ERROR "-skipnops retained the zero-word NOP:\n${skipped_output}")
+endif()
+
+if(NOT skipped_output MATCHES "000002:")
+	message(FATAL_ERROR
+		"-skipnops removed or failed to advance to the following word:\n${skipped_output}")
+endif()

--- a/source/disassemble/disassemble_test.cmake
+++ b/source/disassemble/disassemble_test.cmake
@@ -18,27 +18,32 @@ if(NOT default_result EQUAL 0)
 		"Default disassembly failed (${default_result})\n${default_output}${default_error}")
 endif()
 
-if(NOT default_output MATCHES "000001:.*nop")
-	message(FATAL_ERROR "Default output omitted the zero-word NOP:\n${default_output}")
+if(default_output MATCHES "000001:.*nop")
+	message(FATAL_ERROR "Default output retained the zero-word NOP:\n${default_output}")
+endif()
+
+if(NOT default_output MATCHES "000002:")
+	message(FATAL_ERROR
+		"Default output removed or failed to advance to the following word:\n${default_output}")
 endif()
 
 execute_process(
-	COMMAND "${DISASSEMBLER}" -in "${input_file}" -pc 1 -skipnops
-	RESULT_VARIABLE skipped_result
-	OUTPUT_VARIABLE skipped_output
-	ERROR_VARIABLE skipped_error
+	COMMAND "${DISASSEMBLER}" -in "${input_file}" -pc 1 -nops
+	RESULT_VARIABLE nops_result
+	OUTPUT_VARIABLE nops_output
+	ERROR_VARIABLE nops_error
 )
 
-if(NOT skipped_result EQUAL 0)
+if(NOT nops_result EQUAL 0)
 	message(FATAL_ERROR
-		"-skipnops disassembly failed (${skipped_result})\n${skipped_output}${skipped_error}")
+		"-nops disassembly failed (${nops_result})\n${nops_output}${nops_error}")
 endif()
 
-if(skipped_output MATCHES "000001:.*nop")
-	message(FATAL_ERROR "-skipnops retained the zero-word NOP:\n${skipped_output}")
+if(NOT nops_output MATCHES "000001:.*nop")
+	message(FATAL_ERROR "-nops omitted the zero-word NOP:\n${nops_output}")
 endif()
 
-if(NOT skipped_output MATCHES "000002:")
+if(NOT nops_output MATCHES "000002:")
 	message(FATAL_ERROR
-		"-skipnops removed or failed to advance to the following word:\n${skipped_output}")
+		"-nops removed or failed to advance to the following word:\n${nops_output}")
 endif()


### PR DESCRIPTION
`$000000` is a real executed NOP with a real fall-through edge. When it is omitted the listing stops tiling the input, so the instruction after a run of NOPs loses its only predecessor and reads as unreachable to anything walking those edges. Gaps between printed addresses also become ambiguous — suppressed NOPs, or a word the disassembler could not decode?

**This PR adds `-nops` to print zero words. The default is unchanged: they are still skipped.**

That is a change from how this PR originally stood, which flipped the default instead. Skipping is the right default — ROM images carry long `$000000` padding runs and suppressing them is what keeps a firmware listing readable, which is the everyday use. Making it opt-in gets the same capability without changing behaviour for any existing command line or invalidating anyone's saved listings.

### Validation

- Release build of `dsp56kDisassemble`, clean configure, on Ubuntu.
- `disassemble_test.cmake` pins **both** behaviours and is registered as `dsp56kDisassembleZeroWords`: the default asserts the NOP is absent *and* that the following word is still reached; `-nops` asserts it is present *and* that the following word still appears. Passes 1/1.
- **The test was checked to actually fail.** Inverting the default makes it fail; ignoring the flag entirely (`skipNops = true`) makes it fail; restoring makes it pass. A test that cannot fail would not be worth adding.
- `CommandLine::contains` is an exact lookup in a `std::set<std::string>`, not a substring match, so `-nops` cannot be triggered by any other flag.

Scope: offline disassembler CLI only. No emulator or audio runtime path is touched.
