### PR TITLE
[ignore, sorry]

### DIFF
--- a/source/dsp56kBase/dspassert.h
+++ b/source/dsp56kBase/dspassert.h
@@ -17,6 +17,8 @@ namespace dsp56k
 #define assert( expr )			do { if( !(expr) ) dsp56k::Assert::show( #expr, __func__, __LINE__ ); } while(0)
 #define assertf( expr, msg )	do { if( !(expr) ) dsp56k::Assert::show( msg, __func__, __LINE__ ); } while(0)
 #else
-#define assert( expr )			do {} while(0)
-#define assertf( expr, msg )	do {} while(0)
+// Match the standard disabled assertion expression. Inline functions can see
+// either header; an empty loop gives those definitions different PGO hashes.
+#define assert( expr )			((void)0)
+#define assertf( expr, msg )	((void)0)
 #endif


### PR DESCRIPTION
[EDIT: sorry, meant to open against my fork, you can ignore this!]

Release inline functions can see either the project's disabled assertion macro or the standard header's macro, depending on include order. The empty `do/while` in the project macro adds a control-flow node to Clang's instrumentation, giving the same inline function different profile hashes and counter counts across translation units.

Normalize disabled `assert` and `assertf` to `((void)0)`. Debug assertions and Release argument/message non-evaluation are preserved.

Apple Clang 16 LLVM IR from a downstream integration build reproduced the difference:

| Inline function | Original `jitblock.cpp` hash / counters | Original `jitdspregs.cpp` hash / counters | Both translation units after normalization |
| --- | --- | --- | --- |
| `RegScratch::get()` | `0x60d` / 2 | `0xd160d` / 3 | `0x60d` / 2 |
| `JitScopedReg::get()` | `0x18` / 1 | `0x3458` / 2 | `0x18` / 1 |

Validation:

- On this upstream-based branch, Apple Clang Release/Debug assertion-contract checks pass, including argument evaluation, diagnostic-message evaluation and failure-handler routing.
- The exact same header was validated in downstream Apple ThinLTO/PGO generate/use builds, which completed without reported structural profile mismatch diagnostics.
- [Downstream Windows/MSVC validation](https://github.com/joelanders/gearmulator-md-mm/actions/runs/34131969007) passed all 24 baseline/fixed Release/Debug DSP CTest invocations with zero skips. Six synthetic workloads produced 72 observations with matching state and work counts and no material performance regression detected. That run uses the downstream integration tree, rather than this upstream base.

The branch contains one commit changing only `source/dsp56kBase/dspassert.h` and is based on upstream `e3b48602`.
