### PR TITLE
AGU: wrap a modulo buffer based at address 0 on a step below the base (fixes #5)

### DIFF
--- a/source/dsp56kEmu/agu.h
+++ b/source/dsp56kEmu/agu.h
@@ -45,20 +45,25 @@ namespace dsp56k
 
 				n = signextend<int, 24>(n);
 
+				// Work on the buffer-relative offset in signed arithmetic. r is
+				// unsigned, so for a buffer based at address 0 a step below the
+				// base underflowed and the lower-bound test could never see it.
 				const auto lowerBound = r & ~moduloMask;
-				const auto upperBound = lowerBound + m;
+				const auto wrap = (n & moduloMask) ? modulo : 0;
+
+				auto rel = static_cast<int32_t>(r - lowerBound);
 
 				if constexpr(add)
-					r += n;
+					rel += static_cast<int32_t>(n);
 				else
-					r -= n;
+					rel -= static_cast<int32_t>(n);
 
-				modulo = n & moduloMask ? modulo : 0;
+				if(rel < 0)
+					rel += wrap;
+				else if(rel > static_cast<int32_t>(m))
+					rel -= wrap;
 
-				if(r < lowerBound)
-					r += modulo;
-				if(r > upperBound)
-					r -= modulo;
+				r = lowerBound + static_cast<TWord>(rel);
 				/*
 				if constexpr(add)
 				{

--- a/source/dsp56kEmu/unittests.cpp
+++ b/source/dsp56kEmu/unittests.cpp
@@ -414,6 +414,56 @@ namespace dsp56k
 		{
 			verify(dsp.regs().r[0] == 0x0ba601);
 		});
+
+		// A modulo buffer based at address 0: stepping below the base must wrap
+		// to the top of the buffer (issue #5). Pre-decrement, -n and a negative
+		// +n are the three ways the interpreter could underflow the unsigned r.
+		runTest([&]()
+		{
+			dsp.set_m(2, 0x00003f);
+			dsp.regs().r[2].var = 0x000000;
+
+			emit("move x:-(r2),x0");
+		}, [&]()
+		{
+			verify(dsp.regs().r[2] == 0x00003f);
+		});
+
+		runTest([&]()
+		{
+			dsp.set_m(2, 0x00003f);
+			dsp.regs().r[2].var = 0x000000;
+			dsp.regs().n[2].var = 0x000001;
+
+			emit("move (r2)-n2");
+		}, [&]()
+		{
+			verify(dsp.regs().r[2] == 0x00003f);
+		});
+
+		runTest([&]()
+		{
+			dsp.set_m(2, 0x00003f);
+			dsp.regs().r[2].var = 0x000000;
+
+			emit("move (r2)-");
+		}, [&]()
+		{
+			verify(dsp.regs().r[2] == 0x00003f);
+		});
+
+		runTest([&]()
+		{
+			// a delay line based at 0, read pointer stepping back past the base
+			dsp.set_m(0, 0x001fff);
+			dsp.regs().r[0].var = 0x000005;
+			dsp.regs().n[0].var = 0xfffff0;
+
+			emit("move (r0)+n0");
+		}, [&]()
+		{
+			verify(dsp.regs().r[0] == 0x001ff5);
+		});
 	}
 
 	void UnitTests::aguMultiWrapModulo()


### PR DESCRIPTION
Fixes #5.

`AGU::updateAddressRegister` compares the updated `r` (unsigned) against the buffer's lower bound. For a buffer based at address 0, a step below the base underflows `r`, `r < lowerBound` can never be true, and the `r > upperBound` branch then subtracts the modulo from the underflowed value. Concrete case: `x:-(r2)` with `r2 = 0`, `m2 = 0x3f` gives `0xffffbf`; the chip gives `0x00003f`.

We hit this independently of #5 while running the Elektron Octatrack's DSP56721 payload on the interpreter (the pointer walked into the peripheral registers and armed a timer). Same root cause, same fix in spirit as the one proposed in the issue.

**Change**: do the update on the buffer-relative offset in signed arithmetic (`agu.h`). The multiple-wrap and linear paths are untouched.

**Scope**: the JIT is not affected. `updateAddressRegisterSubModulo` in both `jitops_agu_x64.cpp` (`cmovl`/`cmovg`) and `jitops_agu_aarch64.cpp` (`kLT`/`kGT`) already compares signed. The new tests confirm that on x64: before this change they pass under the JIT and fail under the interpreter.

**Tests**: four cases added to `UnitTests::aguModulo`, which runs under both backends: pre-decrement `x:-(r2)`, `(r2)-n2`, `(r2)-` at base 0 with M = 0x3f, and a base-0 delay line (M = 0x1fff) stepping back past the base. Full `dsp56kTestRunner` passes (assembler 280/280, JIT, interpreter, JIT optimizer). I also compared the old code, the fix from #5 and this one against a plain relative-offset model over every base below 0x10000, every pointer in the buffer and every |N| ≤ M for seven buffer sizes (about 4.5 billion cases): the old code differs only at base 0, and the two fixes agree everywhere.

Disclosure: diagnosis, the exhaustive comparison and this PR were done with Claude Code and reviewed by a human before submission.
